### PR TITLE
Fix dataset configuration bugs

### DIFF
--- a/yolov8_training/utils/data_utils.py
+++ b/yolov8_training/utils/data_utils.py
@@ -227,6 +227,9 @@ def create_dataset_yaml(dataset_path: Path, custom_classes=None, use_coco_classe
         custom_classes: List of custom class names
         use_coco_classes: Whether to use COCO classes when custom_classes is empty
     """
+
+    class_mapping = get_class_mapping(custom_classes, use_coco_classes)
+
     # Get all parts of the path
     yaml_dataset_path = dataset_path.absolute()
 
@@ -234,11 +237,10 @@ def create_dataset_yaml(dataset_path: Path, custom_classes=None, use_coco_classe
 path: {yaml_dataset_path}
 train: train/images
 val: val/images
+nc: {len(class_mapping)} 
 
 names:
 """
-    
-    class_mapping = get_class_mapping(custom_classes, use_coco_classes)
     for key, value in class_mapping.items():
         yaml_content += f"  {key}: {value}\n"
 

--- a/yolov8_training/utils/evaluate.py
+++ b/yolov8_training/utils/evaluate.py
@@ -388,9 +388,7 @@ def calculate_scene_metrics(model, data, **kwargs):
                 "path": str(temp_path),
                 "train": "images",
                 "val": "images",
-                "nc": dataset_config.get(
-                    "nc", 8
-                ),  # Get nc from original yaml or default
+                "nc": len(dataset_config["names"]),
                 "names": dataset_config["names"],
             }
 
@@ -437,8 +435,8 @@ def calculate_scene_metrics(model, data, **kwargs):
 
         finally:
             # Ensure cleanup happens regardless of success or failure after evaluation is finished
-            if temp_dir and temp_dir.exists():
-                shutil.rmtree(temp_dir, ignore_errors=True)
+            if temp_path.exists():
+                shutil.rmtree(temp_path, ignore_errors=True)
 
     return scene_metrics
 


### PR DESCRIPTION
- Fix class mapping calculation order in create_dataset_yaml()
- Fix hardcoded nc=8 to dynamic class count calculation
- Fix temp_dir/temp_path variable name inconsistency

Fixes training failures with 'names' length and 'nc' mismatch errors. Resolves: SyntaxError: 'names' length 2 and 'nc: 8' must match