### PR TITLE
Feature/#1859 fix oversampling

### DIFF
--- a/params.yaml
+++ b/params.yaml
@@ -29,7 +29,7 @@ train:
   batch_size: 8
   # Fine-tuning configuration
   finetune_mode: false  # Set to true to enable fine-tuning
-  pretrained_model_path: taco-uav-model.pt    # Path to pre-trained model
+  pretrained_model_path: yolov8m.pt    # Path to pre-trained model
   finetune_lr: 0.0001   # Lower learning rate for fine-tuning (default YOLO lr is ~0.01)
   finetune_epochs: 60  # Typically fewer epochs needed for fine-tuning
   freeze_backbone: false # Whether to freeze backbone layers during fine-tuning

--- a/tests/test_folder_subsets.py
+++ b/tests/test_folder_subsets.py
@@ -9,17 +9,23 @@ removal by the smart dedup stage.
 """
 
 from pathlib import Path
+import random
 import cv2
 import numpy as np
+import pytest
 
 from yolov8_training.utils.data_utils import process_single_images
 
 
-def test_over_under_sampling(tmp_path: Path):
-    # Build minimal input structure: raw_data/train/{a,b}/{images,labels}
-    # Folder 'a' has 4 images, folder 'b' has 2 images.
-    # Each image gets a distinct pattern so the dedup stage will not remove it.
-    input_root = tmp_path / "raw_data" / "train"
+pytestmark = [
+    pytest.mark.filterwarnings(
+        "ignore:.*use of fork\\(\\) may lead to deadlocks in the child.*:DeprecationWarning"
+    )
+]
+
+
+def _prepare_sources(base_path: Path) -> Path:
+    input_root = base_path / "raw_data" / "train"
     for folder, count, base_val in [("a", 4, 25), ("b", 2, 200)]:
         images = input_root / folder / "images"
         labels = input_root / folder / "labels"
@@ -27,21 +33,33 @@ def test_over_under_sampling(tmp_path: Path):
         labels.mkdir(parents=True, exist_ok=True)
         for i in range(count):
             img = np.full((64, 64, 3), base_val + i, dtype=np.uint8)
-            # Add distinct patterns to avoid near-duplicate detection
             if folder == "a":
                 cv2.rectangle(img, (5 + i, 5 + i), (30 + i, 30 + i), (255, 255, 255), -1)
             else:
                 cv2.circle(img, (32, 32), 10 + i, (255, 255, 255), -1)
-            cv2.imwrite(str(images / f"img_{i}.jpg"), img)
-            with open(labels / f"img_{i}.txt", "w") as f:
+            name = f"{folder}_img_{i}"
+            cv2.imwrite(str(images / f"{name}.jpg"), img)
+            with open(labels / f"{name}.txt", "w") as f:
                 f.write("0 0.5 0.5 0.2 0.2\n")
+    return input_root
 
-    # Output roots
+
+def _base_name(name: str) -> str:
+    if "__dup" not in name:
+        return name
+    stem_part, _ = name.split("__dup", 1)
+    return f"{stem_part}{Path(name).suffix}"
+
+
+def test_over_under_sampling(tmp_path: Path):
+    input_root = _prepare_sources(tmp_path)
+
     train_out = tmp_path / "dataset" / "train"
     test_out = tmp_path / "dataset" / "test"
 
-    # Subsample folder 'a' and oversample folder 'b', verify counts.
     folder_subsets = {"a": 0.5, "b": 2.0}
+
+    random.seed(0)
 
     train_count, val_count, test_count = process_single_images(
         input_path=input_root,
@@ -55,5 +73,71 @@ def test_over_under_sampling(tmp_path: Path):
 
     assert val_count == 0
     assert test_count == 0
-    # Expect exactly 6 pairs in train after subset logic
     assert train_count == 6
+
+    train_images_dir = train_out / "train" / "images"
+    train_labels_dir = train_out / "train" / "labels"
+    img_paths = sorted(train_images_dir.glob("*.jpg"))
+    lbl_paths = sorted(train_labels_dir.glob("*.txt"))
+
+    assert len(img_paths) == len(lbl_paths) == train_count
+
+    names = [p.name for p in img_paths]
+    assert len(set(names)) == len(names)
+
+    dup_names = [n for n in names if "__dup" in n]
+    assert dup_names
+
+    counts_by_stem = {}
+    for name in names:
+        key = _base_name(name)
+        counts_by_stem[key] = counts_by_stem.get(key, 0) + 1
+
+    b_stems = {
+        stem
+        for stem in counts_by_stem
+        if Path(stem).stem.startswith("b_img_")
+    }
+    assert b_stems
+    for stem in b_stems:
+        assert counts_by_stem[stem] == 2
+
+    for stem, count in counts_by_stem.items():
+        if Path(stem).stem.startswith("a_img_"):
+            assert count == 1
+
+
+def test_oversampling_does_not_leak_to_validation(tmp_path: Path):
+    input_root = _prepare_sources(tmp_path)
+
+    train_out = tmp_path / "dataset_split" / "train"
+    test_out = tmp_path / "dataset_split" / "test"
+
+    folder_subsets = {"b": 2.0}
+
+    random.seed(0)
+
+    process_single_images(
+        input_path=input_root,
+        train_output_path=train_out,
+        test_output_path=test_out,
+        val_split=0.5,
+        test_split=0.0,
+        augment_multiplier=1,
+        folder_subsets=folder_subsets,
+    )
+
+    dup_train_imgs = list((train_out / "train" / "images").glob("*__dup*.jpg"))
+    dup_train_lbls = list((train_out / "train" / "labels").glob("*__dup*.txt"))
+    assert dup_train_imgs, "Expected duplicated samples in train split"
+    assert len(dup_train_imgs) == len(dup_train_lbls)
+
+    dup_val_imgs = list((train_out / "val" / "images").glob("*__dup*.jpg"))
+    dup_val_lbls = list((train_out / "val" / "labels").glob("*__dup*.txt"))
+    dup_test_imgs = list((test_out / "val" / "images").glob("*__dup*.jpg"))
+    dup_test_lbls = list((test_out / "val" / "labels").glob("*__dup*.txt"))
+
+    assert not dup_val_imgs
+    assert not dup_val_lbls
+    assert not dup_test_imgs
+    assert not dup_test_lbls

--- a/yolov8_training/utils/data_utils.py
+++ b/yolov8_training/utils/data_utils.py
@@ -842,14 +842,8 @@ def process_single_images(
     # Continue with the processed pairs instead of original image_label_pairs
     image_label_pairs = processed_pairs
 
-    # add augmentation to the remaining images
-    augmented_pairs, aug_temp_folders = augment(image_label_pairs, augment_multiplier)
-
-    temp_folders.extend(aug_temp_folders)
-
     # Shuffle data
     random.shuffle(image_label_pairs)
-    random.shuffle(augmented_pairs)
 
     # Calculate split indices
     total_images = len(image_label_pairs)
@@ -863,6 +857,13 @@ def process_single_images(
 
     # Apply oversampling to training pairs only to avoid leakage
     train_pairs = _oversample_train_pairs(train_pairs, folder_subsets)
+
+    # add augmentation after oversampling so duplicates receive augmentations too
+    augmented_pairs, aug_temp_folders = augment(train_pairs, augment_multiplier)
+
+    temp_folders.extend(aug_temp_folders)
+
+    random.shuffle(augmented_pairs)
 
     # only add augmentation to training data
     train_pairs.extend(augmented_pairs)


### PR DESCRIPTION
- Fix oversampling so we only duplicate training samples rather than inflating every split (avoid leakage into val/test).
- Rework duplication by adding deterministic __dup suffixes when we need multiple copies of the same file name (avoid overwriting files when duplicating)
